### PR TITLE
Added support for deleted DynamoDB records

### DIFF
--- a/functions/streaming/updateSearchCluster.py
+++ b/functions/streaming/updateSearchCluster.py
@@ -22,9 +22,16 @@ def handler(event, context):
     for record in event["Records"]:
         # Get the primary key for use as the Elasticsearch ID
         id = record["dynamodb"]["Keys"]["id"]["S"]
-        print id
+        print "bookId " + id
 
-        document = record["dynamodb"]["NewImage"]
-        r = requests.put(url + id, auth=awsauth, json=document, headers=headers)
-        count += 1
+        try:
+            document = record["dynamodb"]["NewImage"]
+            r = requests.put(url + id, auth=awsauth, json=document, headers=headers)
+            count += 1
+        except KeyError:
+            # this execution path is to cater for deleted records
+            document = record["dynamodb"]["OldImage"]
+            r = requests.delete(url + id, auth=awsauth, json=document, headers=headers)
+            count += 1
+        
     return str(count) + " records processed."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without this change, Lambda starts failing for all subsequent records (new or deleted) as soon as a record in deleted. Deleted records in DynamoDB come through with the key name "OldImage", which was not catered for in the lambda.

This change will make it easier for experimenting and learning from this demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
