### PR TITLE
Updated NodeJS Lambdas runtime from 12.x to 16.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*~
+.*~
+.*.swp
+*.pyc
+.DS_Store
+*.lock

--- a/template/master-fullstack-with-lambda-warmers.yaml
+++ b/template/master-fullstack-with-lambda-warmers.yaml
@@ -833,7 +833,7 @@ Resources:
       Role: !GetAtt 
         - RedisRole
         - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: '60'
       VpcConfig:
         SecurityGroupIds:
@@ -891,7 +891,7 @@ Resources:
       Description: Get list of books ordered by customerId
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -918,7 +918,7 @@ Resources:
       Description: Get book by id
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -945,7 +945,7 @@ Resources:
       Description: Get list of books by category
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -972,7 +972,7 @@ Resources:
       Description: Update Customer's cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -999,7 +999,7 @@ Resources:
       Description: Get item in cart by customer and book id
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1026,7 +1026,7 @@ Resources:
       Description: Get list of items in cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1053,7 +1053,7 @@ Resources:
       Description: Add a book to cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1080,7 +1080,7 @@ Resources:
       Description: Remove a book from cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1107,7 +1107,7 @@ Resources:
       Description: Get list of books ordered by customerId
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1135,7 +1135,7 @@ Resources:
       FunctionName: !Sub '${ProjectName}-UploadBooks'
       Description: Upload sample data for books
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1284,7 +1284,7 @@ Resources:
       Role: !GetAtt
         - RedisRole
         - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: '60'
       VpcConfig:
         SecurityGroupIds:
@@ -2828,7 +2828,7 @@ Resources:
         'Fn::GetAtt':
           - CreateOSRole
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 300
     Type: 'AWS::Lambda::Function'
   ESRoleCreator:
@@ -2857,7 +2857,7 @@ Resources:
         'Fn::GetAtt':
           - SeederRole
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 300
       Environment:
         Variables:

--- a/template/master-fullstack.yaml
+++ b/template/master-fullstack.yaml
@@ -832,7 +832,7 @@ Resources:
       Role: !GetAtt 
         - RedisRole
         - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: '60'
       VpcConfig:
         SecurityGroupIds:
@@ -890,7 +890,7 @@ Resources:
       Description: Get list of books ordered by customerId
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -917,7 +917,7 @@ Resources:
       Description: Get book by id
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -944,7 +944,7 @@ Resources:
       Description: Get list of books by category
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -971,7 +971,7 @@ Resources:
       Description: Update Customer's cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -998,7 +998,7 @@ Resources:
       Description: Get item in cart by customer and book id
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1025,7 +1025,7 @@ Resources:
       Description: Get list of items in cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1052,7 +1052,7 @@ Resources:
       Description: Add a book to cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1079,7 +1079,7 @@ Resources:
       Description: Remove a book from cart
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1106,7 +1106,7 @@ Resources:
       Description: Get list of books ordered by customerId
       Handler: index.handler
       MemorySize: 256
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1134,7 +1134,7 @@ Resources:
       FunctionName: !Sub '${ProjectName}-UploadBooks'
       Description: Upload sample data for books
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Role: !GetAtt 
         - DynamoDbRole
         - Arn
@@ -1283,7 +1283,7 @@ Resources:
       Role: !GetAtt
         - RedisRole
         - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: '60'
       VpcConfig:
         SecurityGroupIds:
@@ -2827,7 +2827,7 @@ Resources:
         'Fn::GetAtt':
           - CreateOSRole
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 300
     Type: 'AWS::Lambda::Function'
   ESRoleCreator:
@@ -2856,7 +2856,7 @@ Resources:
         'Fn::GetAtt':
           - SeederRole
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:* Issue #49

*Description of changes:*  Updated Lambda runtime of NodeJS AWS Lambda functions from 12.x to 16.x due to 12.x deprecation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
