### PR TITLE
Adding dependency of route table associations to Neptune Loader

### DIFF
--- a/template/master-fullstack-with-lambda-warmers.yaml
+++ b/template/master-fullstack-with-lambda-warmers.yaml
@@ -357,6 +357,8 @@ Resources:
       - bookstoreNeptuneLoaderLambda
       - bookstoreNeptuneLoaderS3ReadPolicy
       - bookstoreNeptuneLoaderS3ReadRole
+      - bookstoreVPCRouteTableAssociation
+      - bookstoreVPCRouteTableAssociationTwo
       - S3Endpoint
     Type: "Custom::NeptuneLoader"
     Properties: 

--- a/template/master-fullstack.yaml
+++ b/template/master-fullstack.yaml
@@ -356,6 +356,8 @@ Resources:
       - bookstoreNeptuneLoaderLambda
       - bookstoreNeptuneLoaderS3ReadPolicy
       - bookstoreNeptuneLoaderS3ReadRole
+      - bookstoreVPCRouteTableAssociation
+      - bookstoreVPCRouteTableAssociationTwo
       - S3Endpoint
     Type: "Custom::NeptuneLoader"
     Properties: 


### PR DESCRIPTION
*Issue #, if available:* Issue #52

*Description of changes:*
Fixing issue with deletion of the stack.  Neptune Loader resource attempts to get deleted after the route table associations are deleted for the two subnets used by the Loader resource.  Added both route table association resources under the list of `DependsOn` under the Neptune Loader resource to ensure these do not get deleted until after the Neptune Loader resource is deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
