### PR TITLE
Replacing valid value from None to NONE.

### DIFF
--- a/template/master-fullstack.yaml
+++ b/template/master-fullstack.yaml
@@ -1579,7 +1579,7 @@ Resources:
     Properties:
       ResourceId: !Ref RecommendationsApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -1637,7 +1637,7 @@ Resources:
     Properties:
       ResourceId: !Ref RecommendationsByBookApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -1698,7 +1698,7 @@ Resources:
     Properties:
       ResourceId: !Ref BooksApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -1763,7 +1763,7 @@ Resources:
     Properties:
       ResourceId: !Ref BookItemApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -1853,7 +1853,7 @@ Resources:
     Properties:
       ResourceId: !Ref OrdersApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -2003,7 +2003,7 @@ Resources:
     Properties:
       ResourceId: !Ref CartApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -2066,7 +2066,7 @@ Resources:
     Properties:
       ResourceId: !Ref CartItemApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -2126,7 +2126,7 @@ Resources:
     Properties:
       ResourceId: !Ref SearchApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK
@@ -2181,7 +2181,7 @@ Resources:
     Properties:
       ResourceId: !Ref BestsellersApiResource
       RestApiId: !Ref AppApi
-      AuthorizationType: None
+      AuthorizationType: NONE
       HttpMethod: OPTIONS
       Integration:
         Type: MOCK


### PR DESCRIPTION
This is the fix for (CloudFormation wizard give error #56)

*Issue #, if available:*
Fixing #56 
(https://github.com/aws-samples/aws-bookstore-demo-app/issues/56)

*Description of changes:*
Replacing AuthorizationType None with NONE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
